### PR TITLE
[FIX] [ABOUT] -- Background Split issue

### DIFF
--- a/frontend/app/ui/home/About.tsx
+++ b/frontend/app/ui/home/About.tsx
@@ -8,9 +8,9 @@ export default function About() {
   return (
     <section id="about" className="relative py-28 px-4 md:px-12 bg-blue-50 overflow-hidden">
       {/* Background split */}
-      <div className="absolute inset-0 z-0 flex">
-        <div className="w-1/3 bg-white"></div>
-        <div className="w-2/3 bg-blue-50"></div>
+      <div className="absolute inset-0 z-0 flex flex-col lg:flex-row">
+        <div className="h-1/2 lg:h-full lg:w-1/3 bg-white"></div>
+        <div className="h-1/2 lg:h-full lg:w-2/3 bg-blue-50"></div>
       </div>
 
       {/* Content container */}
@@ -27,7 +27,7 @@ export default function About() {
           </div>
 
           {/* Content column */}
-          <div className="order-1 md:order-2 flex flex-col space-y-6">
+          <div className="order-1 md:order-2 flex flex-col space-y-6 pt-40 md:pt-0">
             <h2 className="text-md font-bold text-gray-700">
               ABOUT US
             </h2>


### PR DESCRIPTION
Description:  Fixed the mobile background split for About section so the Text only appears on the blue background and the image on white


process:
    -  Changed background split from horizontal to vertical on mobile using flex-col
    -  Added top padding to push content into blue section on mobile

Before: 
![IMG_0796](https://github.com/user-attachments/assets/d4a07e62-8d99-4f43-afef-9014d48de1ef)



After: 
![IMG_0794](https://github.com/user-attachments/assets/c9fa3d94-e837-4562-867a-a3a54c2a6626)
![IMG_0795](https://github.com/user-attachments/assets/cd327a19-2328-475b-97a0-c4e2347666b4)

