### PR TITLE
[fix] [Navbar] -- navbar transparent bg issue

### DIFF
--- a/frontend/app/components/navbar.tsx
+++ b/frontend/app/components/navbar.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import logo from "../images/logo/logo.svg";
+import { usePathname } from 'next/navigation';
 
 
 interface NavItems {
@@ -37,6 +38,9 @@ const navitems: NavItems[] = [
 export default function Navbar() {
   const [scrolled, setScrolled] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const pathname = usePathname();
+  const isHomePage = pathname === '/';
+
 
   // Handle scroll event to change navbar appearance
   useEffect(() => {
@@ -76,7 +80,7 @@ export default function Navbar() {
   return (
     <nav
       className={`fixed w-full z-50 transition-all duration-300 ${
-        scrolled || mobileMenuOpen
+        !isHomePage || scrolled || mobileMenuOpen
           ? "bg-zinc-900 shadow-md py-2"
           : "bg-transparent py-4"
       }`}


### PR DESCRIPTION
Navbar bg color turns transparent when scrolled up only in home page
- checks the condition if current page is homepage
- applies bg-transparent only if it's the homepage


Before:
![localhost_3000_schedule-a-consultation - Google Chrome 2025-07-17 02-17-33](https://github.com/user-attachments/assets/2d78fe30-1861-4aad-a1bc-9b4026a9b851)


After:

![localhost_3000_schedule-a-consultation - Google Chrome 2025-07-17 02-18-05](https://github.com/user-attachments/assets/b9ed49fe-a024-42cd-94d6-5c87c882b9db)

